### PR TITLE
Add core A-share strategies and data helpers

### DIFF
--- a/data/providers/tushare_provider.py
+++ b/data/providers/tushare_provider.py
@@ -336,6 +336,66 @@ class TushareProvider:
         except Exception as e:
             logger.error(f"获取每日基本面数据失败: {e}")
             raise DataProviderError(f"获取每日基本面数据失败: {e}")
+
+    def get_top_list(self, start_date: Optional[str] = None,
+                     end_date: Optional[str] = None,
+                     trade_date: Optional[str] = None) -> pd.DataFrame:
+        """获取龙虎榜数据"""
+        try:
+            params: Dict[str, Any] = {}
+            if trade_date:
+                params['trade_date'] = trade_date.replace('-', '')
+            if start_date:
+                params['start_date'] = start_date.replace('-', '')
+            if end_date:
+                params['end_date'] = end_date.replace('-', '')
+
+            df = self._make_request('top_list', **params)
+            if not df.empty:
+                df['trade_date'] = pd.to_datetime(df['trade_date'])
+            return df
+        except Exception as e:
+            logger.error(f"获取龙虎榜数据失败: {e}")
+            raise DataProviderError(f"获取龙虎榜数据失败: {e}")
+
+    def get_block_trade(self, ts_code: Optional[str] = None,
+                        start_date: Optional[str] = None,
+                        end_date: Optional[str] = None) -> pd.DataFrame:
+        """获取大宗交易数据"""
+        try:
+            params: Dict[str, Any] = {}
+            if ts_code:
+                params['ts_code'] = ts_code
+            if start_date:
+                params['start_date'] = start_date.replace('-', '')
+            if end_date:
+                params['end_date'] = end_date.replace('-', '')
+
+            df = self._make_request('block_trade', **params)
+            if not df.empty:
+                df['trade_date'] = pd.to_datetime(df['trade_date'])
+            return df
+        except Exception as e:
+            logger.error(f"获取大宗交易数据失败: {e}")
+            raise DataProviderError(f"获取大宗交易数据失败: {e}")
+
+    def get_moneyflow(self, ts_code: str, start_date: Optional[str] = None,
+                      end_date: Optional[str] = None) -> pd.DataFrame:
+        """获取资金流向数据"""
+        try:
+            params: Dict[str, Any] = {'ts_code': ts_code}
+            if start_date:
+                params['start_date'] = start_date.replace('-', '')
+            if end_date:
+                params['end_date'] = end_date.replace('-', '')
+
+            df = self._make_request('moneyflow', **params)
+            if not df.empty:
+                df['trade_date'] = pd.to_datetime(df['trade_date'])
+            return df
+        except Exception as e:
+            logger.error(f"获取资金流向数据失败: {e}")
+            raise DataProviderError(f"获取资金流向数据失败: {e}")
     
     def _validate_price_data(self, df: pd.DataFrame) -> pd.DataFrame:
         """验证价格数据的有效性"""
@@ -454,5 +514,9 @@ class TushareProvider:
             logger.error(f"批量获取日线数据失败: {e}")
             raise DataProviderError(f"批量获取日线数据失败: {e}")
 
-# 全局Tushare提供商实例
-tushare_provider = TushareProvider()
+# 全局Tushare提供商实例（可能因未配置token而为空）
+try:
+    tushare_provider = TushareProvider()
+except Exception as e:
+    tushare_provider = None
+    logger.warning(f"无法初始化TushareProvider: {e}")

--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -10,9 +10,12 @@ from .base import (
     SignalGenerator,
     Trade,
     BacktestEngine,
-    MACrossoverStrategy,
-    MACDStrategy,
 )
+
+from .master_tracking_strategy import MasterTrackingStrategy
+from .sector_rotation_strategy import SectorRotationStrategy
+from .multi_factor_strategy import MultiFactorStrategy
+from .capital_flow_strategy import CapitalFlowStrategy
 
 __all__ = [
     "SignalType",
@@ -24,6 +27,8 @@ __all__ = [
     "SignalGenerator",
     "Trade",
     "BacktestEngine",
-    "MACrossoverStrategy",
-    "MACDStrategy",
+    "MasterTrackingStrategy",
+    "SectorRotationStrategy",
+    "MultiFactorStrategy",
+    "CapitalFlowStrategy",
 ]

--- a/strategies/capital_flow_strategy.py
+++ b/strategies/capital_flow_strategy.py
@@ -1,0 +1,58 @@
+"""资金博弈分析策略"""
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import List
+import pandas as pd
+
+from strategies.base.strategy_base import (
+    StrategyBase,
+    StrategyConfig,
+    TradingSignal,
+    SignalType,
+)
+from data.providers.tushare_provider import TushareProvider
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class CapitalFlowStrategy(StrategyBase):
+    """基于资金流向的简单短线策略"""
+
+    def __init__(self, config: StrategyConfig, lookback: int = 3):
+        super().__init__(config)
+        self.lookback = lookback
+        try:
+            self.provider = TushareProvider()
+        except Exception as e:  # pragma: no cover
+            logger.warning(f"无法初始化TushareProvider: {e}")
+            self.provider = None
+
+    def generate_signals(self, data: pd.DataFrame) -> List[TradingSignal]:
+        if data.empty or self.provider is None:
+            return []
+        ts_code = data['ts_code'].iloc[0]
+        end = data['trade_date'].iloc[-1]
+        start = (end - timedelta(days=self.lookback * 2)).strftime('%Y%m%d')
+        end_str = end.strftime('%Y%m%d')
+        try:
+            mf = self.provider.get_moneyflow(ts_code, start_date=start, end_date=end_str)
+        except Exception as e:
+            logger.debug(f"获取资金流数据失败: {e}")
+            return []
+        if mf.empty or 'net_mf_amount' not in mf.columns:
+            return []
+        mf = mf.sort_values('trade_date')
+        recent = mf['net_mf_amount'].tail(self.lookback)
+        if recent.sum() > 0 and recent.iloc[-1] > 0:
+            signal = TradingSignal(
+                ts_code=ts_code,
+                trade_date=end,
+                signal_type=SignalType.BUY,
+                price=data['close_price'].iloc[-1],
+                confidence=0.6,
+                reason='moneyflow_positive'
+            )
+            return [signal]
+        return []

--- a/strategies/master_tracking_strategy.py
+++ b/strategies/master_tracking_strategy.py
@@ -1,0 +1,75 @@
+"""主力资金跟踪策略"""
+from __future__ import annotations
+
+from typing import List
+import pandas as pd
+
+from strategies.base.strategy_base import (
+    StrategyBase,
+    StrategyConfig,
+    TradingSignal,
+    SignalType,
+)
+from data.providers.tushare_provider import TushareProvider
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class MasterTrackingStrategy(StrategyBase):
+    """通过龙虎榜和大宗交易跟踪主力资金的策略"""
+
+    def __init__(self, config: StrategyConfig):
+        super().__init__(config)
+        try:
+            self.provider = TushareProvider()
+        except Exception as e:  # pragma: no cover - 无token环境下不报错
+            logger.warning(f"无法初始化TushareProvider: {e}")
+            self.provider = None
+
+    def generate_signals(self, data: pd.DataFrame) -> List[TradingSignal]:
+        if data.empty or self.provider is None:
+            return []
+
+        ts_code = data['ts_code'].iloc[0]
+        trade_date = data['trade_date'].iloc[-1]
+        date_str = trade_date.strftime('%Y%m%d')
+
+        reasons = []
+        confidence = 0.5
+
+        try:
+            lhb = self.provider.get_top_list(trade_date=date_str)
+            if not lhb.empty:
+                record = lhb[lhb['ts_code'] == ts_code]
+                if not record.empty and record['net_amount'].iloc[0] > 1e7:
+                    reasons.append('top_list_net_buy')
+                    confidence += 0.2
+        except Exception as e:
+            logger.debug(f"获取龙虎榜数据失败: {e}")
+
+        try:
+            block = self.provider.get_block_trade(ts_code=ts_code,
+                                                  start_date=date_str,
+                                                  end_date=date_str)
+            if not block.empty:
+                premium = (block['price'] - block['pre_close']) / block['pre_close']
+                if premium.mean() > 0:
+                    reasons.append('block_trade_premium')
+                    confidence += 0.2
+        except Exception as e:
+            logger.debug(f"获取大宗交易数据失败: {e}")
+
+        if not reasons:
+            return []
+
+        price = data['close_price'].iloc[-1]
+        signal = TradingSignal(
+            ts_code=ts_code,
+            trade_date=trade_date,
+            signal_type=SignalType.BUY,
+            price=price,
+            confidence=min(1.0, confidence),
+            reason=','.join(reasons),
+        )
+        return [signal]

--- a/strategies/multi_factor_strategy.py
+++ b/strategies/multi_factor_strategy.py
@@ -1,0 +1,75 @@
+"""多因子选股策略"""
+from __future__ import annotations
+
+from typing import List
+import numpy as np
+import pandas as pd
+
+from strategies.base.strategy_base import (
+    StrategyBase,
+    StrategyConfig,
+    TradingSignal,
+    SignalType,
+)
+from data.providers.tushare_provider import TushareProvider
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class MultiFactorStrategy(StrategyBase):
+    """动量、估值与换手率的简单多因子模型"""
+
+    def __init__(self, config: StrategyConfig, lookback: int = 20):
+        super().__init__(config)
+        self.lookback = lookback
+        try:
+            self.provider = TushareProvider()
+        except Exception as e:  # pragma: no cover
+            logger.warning(f"无法初始化TushareProvider: {e}")
+            self.provider = None
+
+    def generate_signals(self, data: pd.DataFrame) -> List[TradingSignal]:
+        if data.empty:
+            return []
+        ts_code = data['ts_code'].iloc[0]
+        if len(data) <= self.lookback:
+            return []
+        close = data.sort_values('trade_date')['close_price']
+        momentum = close.iloc[-1] / close.iloc[-self.lookback-1] - 1
+
+        pe = np.nan
+        turnover = np.nan
+        if self.provider is not None:
+            try:
+                basic = self.provider.get_daily_basic(
+                    ts_code=ts_code,
+                    trade_date=data['trade_date'].iloc[-1].strftime('%Y%m%d'),
+                )
+                if not basic.empty:
+                    pe = basic.get('pe_ttm', np.nan).iloc[0]
+                    turnover = basic.get('turnover_rate', np.nan).iloc[0]
+            except Exception as e:
+                logger.debug(f"获取daily_basic失败: {e}")
+
+        scores = []
+        if not np.isnan(momentum):
+            scores.append(momentum)
+        if not np.isnan(pe) and pe > 0:
+            scores.append(-pe / 100)  # 估值越低越好
+        if not np.isnan(turnover):
+            scores.append(turnover / 100)
+        if not scores:
+            return []
+        score = float(np.mean(scores))
+        if score <= 0:
+            return []
+        signal = TradingSignal(
+            ts_code=ts_code,
+            trade_date=data['trade_date'].iloc[-1],
+            signal_type=SignalType.BUY,
+            price=data['close_price'].iloc[-1],
+            confidence=min(1.0, 0.5 + score),
+            reason='multi_factor'
+        )
+        return [signal]

--- a/strategies/sector_rotation_strategy.py
+++ b/strategies/sector_rotation_strategy.py
@@ -1,0 +1,74 @@
+"""板块轮动策略"""
+from __future__ import annotations
+
+from typing import Dict, List, Set
+import pandas as pd
+import numpy as np
+
+from strategies.base.strategy_base import (
+    StrategyBase,
+    StrategyConfig,
+    TradingSignal,
+    SignalType,
+)
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class SectorRotationStrategy(StrategyBase):
+    """简单的板块轮动策略"""
+
+    def __init__(self, config: StrategyConfig, sector_map: Dict[str, List[str]],
+                 lookback: int = 20, top_n: int = 3):
+        super().__init__(config)
+        self.sector_map = sector_map
+        self.lookback = lookback
+        self.top_n = top_n
+        self.stock_to_sector = {
+            code: sector for sector, codes in sector_map.items() for code in codes
+        }
+        self.top_sectors: Set[str] = set()
+
+    def _compute_sector_strength(self, start_date: str, end_date: str):
+        sector_returns: Dict[str, float] = {}
+        for sector, codes in self.sector_map.items():
+            rets = []
+            for code in codes:
+                df = self.repository.get_daily_price(code, start_date, end_date)
+                if df.empty or len(df) <= self.lookback:
+                    continue
+                close = df.sort_values('trade_date')['close_price']
+                ret = close.iloc[-1] / close.iloc[-self.lookback-1] - 1
+                rets.append(ret)
+            sector_returns[sector] = float(np.mean(rets)) if rets else -np.inf
+        self.top_sectors = set(
+            sorted(sector_returns, key=sector_returns.get, reverse=True)[: self.top_n]
+        )
+
+    def run_strategy(self, ts_codes: List[str], start_date: str, end_date: str):
+        self._compute_sector_strength(start_date, end_date)
+        return super().run_strategy(ts_codes, start_date, end_date)
+
+    def generate_signals(self, data: pd.DataFrame) -> List[TradingSignal]:
+        if data.empty:
+            return []
+        ts_code = data['ts_code'].iloc[0]
+        sector = self.stock_to_sector.get(ts_code)
+        if sector not in self.top_sectors:
+            return []
+        if len(data) <= self.lookback:
+            return []
+        close = data.sort_values('trade_date')['close_price']
+        ret = close.iloc[-1] / close.iloc[-self.lookback-1] - 1
+        if ret <= 0:
+            return []
+        signal = TradingSignal(
+            ts_code=ts_code,
+            trade_date=data['trade_date'].iloc[-1],
+            signal_type=SignalType.BUY,
+            price=data['close_price'].iloc[-1],
+            confidence=0.6,
+            reason=f"sector:{sector}"
+        )
+        return [signal]


### PR DESCRIPTION
## Summary
- extend Tushare provider with top list, block trade and moneyflow APIs
- implement MasterTracking, SectorRotation, MultiFactor and CapitalFlow strategies
- expose new strategies in package

## Testing
- `python -m py_compile strategies/master_tracking_strategy.py strategies/sector_rotation_strategy.py strategies/multi_factor_strategy.py strategies/capital_flow_strategy.py data/providers/tushare_provider.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890aec7a4148326af19e2874039d8d1